### PR TITLE
still cant believe this works

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -143,22 +143,59 @@ class SettingsScreen extends StatelessWidget {
             ),
           ),
           const Divider(),
-          // Test mode toggle
-          SwitchListTile(
-            secondary: const Icon(Icons.bug_report),
-            title: const Text('Test Mode'),
-            subtitle: const Text('Simulate uploads without sending to OSM'),
-            value: appState.testMode,
-            onChanged: (value) => appState.setTestMode(value),
+          // Upload mode selector - Production/Sandbox/Simulate
+          ListTile(
+            leading: const Icon(Icons.cloud_upload),
+            title: const Text('Upload Destination'),
+            subtitle: const Text('Choose where cameras are uploaded'),
+            trailing: DropdownButton<UploadMode>(
+              value: appState.uploadMode,
+              items: const [
+                DropdownMenuItem(
+                  value: UploadMode.production,
+                  child: Text('Production'),
+                ),
+                DropdownMenuItem(
+                  value: UploadMode.sandbox,
+                  child: Text('Sandbox'),
+                ),
+                DropdownMenuItem(
+                  value: UploadMode.simulate,
+                  child: Text('Simulate'),
+                ),
+              ],
+              onChanged: (mode) {
+                if (mode != null) appState.setUploadMode(mode);
+              },
+            ),
+          ),
+          // Help text
+          Padding(
+            padding: const EdgeInsets.only(left: 56, top: 2, right: 16, bottom: 12),
+            child: Builder(
+              builder: (context) {
+                switch (appState.uploadMode) {
+                  case UploadMode.production:
+                    return const Text('Upload to the live OSM database (visible to all users)', style: TextStyle(fontSize: 12, color: Colors.black87));
+                  case UploadMode.sandbox:
+                    return const Text('Upload to the OSM Sandbox (safe for testing, data resets regularly)', style: TextStyle(fontSize: 12, color: Colors.orange));
+                  case UploadMode.simulate:
+                  default:
+                    return const Text('Simulate uploads (does not contact OSM servers)', style: TextStyle(fontSize: 12, color: Colors.deepPurple));
+                }
+              },
+            ),
           ),
           const Divider(),
           // Queue management
           ListTile(
             leading: const Icon(Icons.queue),
             title: Text('Pending uploads: ${appState.pendingCount}'),
-            subtitle: appState.testMode 
-                ? const Text('Test mode enabled - uploads simulated')
-                : const Text('Tap to view queue'),
+            subtitle: appState.uploadMode == UploadMode.simulate
+                ? const Text('Simulate mode enabled – uploads simulated')
+                : appState.uploadMode == UploadMode.sandbox
+                    ? const Text('Sandbox mode – uploads go to OSM Sandbox')
+                    : const Text('Tap to view queue'),
             onTap: appState.pendingCount > 0 ? () {
               _showQueueDialog(context, appState);
             } : null,

--- a/lib/services/uploader.dart
+++ b/lib/services/uploader.dart
@@ -3,11 +3,14 @@ import 'package:http/http.dart' as http;
 
 import '../models/pending_upload.dart';
 
+import '../app_state.dart';
+
 class Uploader {
-  Uploader(this.accessToken, this.onSuccess);
+  Uploader(this.accessToken, this.onSuccess, {this.uploadMode = UploadMode.production});
 
   final String accessToken;
   final void Function() onSuccess;
+  final UploadMode uploadMode;
 
   Future<bool> upload(PendingUpload p) async {
     try {
@@ -68,14 +71,24 @@ class Uploader {
     }
   }
 
+  String get _host {
+    switch (uploadMode) {
+      case UploadMode.sandbox:
+        return 'api06.dev.openstreetmap.org';
+      case UploadMode.production:
+      default:
+        return 'api.openstreetmap.org';
+    }
+  }
+
   Future<http.Response> _post(String path, String body) => http.post(
-        Uri.https('api.openstreetmap.org', path),
+        Uri.https(_host, path),
         headers: _headers,
         body: body,
       );
 
   Future<http.Response> _put(String path, String body) => http.put(
-        Uri.https('api.openstreetmap.org', path),
+        Uri.https(_host, path),
         headers: _headers,
         body: body,
       );


### PR DESCRIPTION
A number of things including:
- production/sandbox/simulate modes for testing (still need to fix osm user shared between prod/sandbox)
- tap on a camera to see details
- better default tags for new custom profiles
- remove ability to upload with default "generic flock" profile
- update the map immediately when changing or enabling/disabling profiles; no longer have to move the map to update points.
- probably a couple other things